### PR TITLE
Changed the way how to resolve dynamic libraries on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ $ npm install uplink-nodejs
         ```
       OR
     * Copy libuplinkc*.* files from $PROJECTROOT/node_modules/uplink-nodejs/ to /usr/local/lib
+  * Linux
+    * Set LD_LIBRARY_PATH  environment variable
+      * Run following command inside root directory of your project
+        ```
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/node_modules/uplink-nodejs/
+        ```
+      OR
+    * Copy libuplinkc*.* files from $PROJECTROOT/node_modules/uplink-nodejs/ to /usr/lib
    * Windows
      * Set Path environment variable to libuplinkc*.* which is  $PROJECTROOT/node_modules/uplink-nodejs
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,7 @@
           "target_name": "uplink",
           "include_dirs": ["./functions"],
           "sources":["./libUplink.cc", "./functions/promises_execute.cc", "./functions/promises_complete.cc", "./functions/project_operations.cc", "./functions/download_operations.cc", "./functions/upload_operations.cc", "./functions/access_operations.cc", "./functions/bucket_operations.cc", "./functions/object_operations.cc" ],
-          "libraries":["<(module_root_dir)/libuplinkcv1.2.4.so"],
+          "libraries":["-L/<(module_root_dir)", "-luplinkcv1.2.4"],
           "ldflags": ["-Wl,-rpath,'$$ORIGIN'"],
           "cflags_cc": ["-fexceptions","-fPIC","-Wno-unknown-pragmas"]
         }


### PR DESCRIPTION
I changed how the shared library will be linked in binding.gyp in the Linux section, the same way it happens on macOS.
More details I've described in [this issue](https://github.com/storj-thirdparty/uplink-nodejs/issues/45).

In `README.md` I've added a section on how to configure the environment in Linux. Unlike macOS, the dynamic linker by some reason can't find shared libraries in `/usr/local/lib` (at least in ubuntu inside docker container), so I recommended putting `libuplikcv` files into /`usr/lib` or configuring `LD_LIBRARY_PATH`.