### PR TITLE
Add non-interactive flag to rmdir (Win) in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build:
 ifdef OS
 	git clone -b ${UPLINKC_VERSION} ${GIT_REPO}
 	(cd ${UPLINKC_NAME}) && (${GOBUILD} -o ../${LIBRARY_NAME_WIN} -buildmode=c-shared) && (move ${LIBRARY_UPLINK} ../)
-	rmdir /s ${UPLINKC_NAME}
+	rmdir /s /q ${UPLINKC_NAME}
 else
 	echo "$(shell uname)";\
      if [ ! -d $(UPLINKC_NAME) ]; then\


### PR DESCRIPTION
Added non-interactive flag to rmdir in Makefile to prevent `npm install uplink-nodejs` to fail.

 
![image](https://user-images.githubusercontent.com/32310370/169530547-cf4493d1-d1b5-45b4-bcb1-5cafcd82907a.png)
